### PR TITLE
Unlock http gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,38 +3,42 @@ PATH
   specs:
     contentful-migrations (0.1.4)
       contentful-management (~> 2.6)
-      http (~> 4.1.1)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    addressable (2.7.0)
+    addressable (2.8.0)
       public_suffix (>= 2.0.2, < 5.0)
     byebug (10.0.2)
     coderay (1.1.2)
-    contentful-management (2.12.0)
+    contentful-management (2.13.1)
       http (> 1.0, < 5.0)
       json (>= 1.8, < 3.0)
       multi_json (~> 1)
     diff-lcs (1.3)
     domain_name (0.5.20190701)
       unf (>= 0.0.5, < 1.0.0)
-    http (4.1.1)
+    ffi (1.15.5)
+    ffi-compiler (1.0.1)
+      ffi (>= 1.0.0)
+      rake
+    http (4.4.1)
       addressable (~> 2.3)
       http-cookie (~> 1.0)
-      http-form_data (~> 2.0)
-      http_parser.rb (~> 0.6.0)
-    http-cookie (1.0.3)
+      http-form_data (~> 2.2)
+      http-parser (~> 1.2.0)
+    http-cookie (1.0.4)
       domain_name (~> 0.5)
     http-form_data (2.3.0)
-    http_parser.rb (0.6.0)
-    json (2.3.0)
+    http-parser (1.2.3)
+      ffi-compiler (>= 1.0, < 2.0)
+    json (2.6.1)
     method_source (0.9.2)
-    multi_json (1.14.1)
+    multi_json (1.15.0)
     pry (0.12.2)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
-    public_suffix (4.0.3)
+    public_suffix (4.0.7)
     rake (12.3.2)
     rspec (3.8.0)
       rspec-core (~> 3.8.0)
@@ -51,7 +55,7 @@ GEM
     rspec-support (3.8.0)
     unf (0.1.4)
       unf_ext
-    unf_ext (0.0.7.6)
+    unf_ext (0.0.8.1)
 
 PLATFORMS
   ruby

--- a/contentful-migrations.gemspec
+++ b/contentful-migrations.gemspec
@@ -30,7 +30,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'contentful-management', '~> 2.6'
-  spec.add_dependency 'http', '~> 4.1.1'
 
   spec.add_development_dependency 'pry'
   spec.add_development_dependency 'bundler', '~> 1.16'


### PR DESCRIPTION
4.1.1 is incompatible with current taxjar-ruby